### PR TITLE
Fix comment highlighter

### DIFF
--- a/apps/code-review/src/app/pages/overview/components/code-editor/directives/line-highlighter.directive.ts
+++ b/apps/code-review/src/app/pages/overview/components/code-editor/directives/line-highlighter.directive.ts
@@ -36,11 +36,12 @@ export class LineHighlighterDirective implements OnDestroy {
 
     private initEditorModelContentInitListener(): void {
         this.editorModelListener = this.editor.onDidChangeModelContent(() => {
-            this.commentsObserver?.unsubscribe();
-
             this.initDecorationsToAllLines();
             this.initEditorMouseDownListener();
-            this.initEditorCommentsObserver();
+
+            if (!this.commentsObserver) {
+                this.initEditorCommentsObserver();
+            }
         });
     }
 


### PR DESCRIPTION
При відкритті файлу с підсвіткою рідків з коментам та потім при відкритті іншого файлу виявлялось, що декоратори підсвітки залишаються, хоча коментів в файлі немає. Тригер зміни контенту моделі спрацюває перш ніж ми підписуємось на стейт з коментарями